### PR TITLE
Introducing events

### DIFF
--- a/src/Events/CreatedEvent.php
+++ b/src/Events/CreatedEvent.php
@@ -5,7 +5,7 @@ namespace Biegalski\LaravelMailgunWebhooks\Events;
 use \Biegalski\LaravelMailgunWebhooks\Model\MailgunEvent;
 use Illuminate\Queue\SerializesModels;
 
-class SaveEvent
+class CreatedEvent
 {
     use SerializesModels;
 

--- a/src/Events/SaveEvent.php
+++ b/src/Events/SaveEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Biegalski\LaravelMailgunWebhooks\Events;
+
+use Biegalski\LaravelMailgunWebhooks\Model\MailgunEvent;
+use Illuminate\Queue\SerializesModels;
+
+class SaveEvent
+{
+    use SerializesModels;
+
+    public $event;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \Biegalski\LaravelMailgunWebhooks\Model\MailgunEvent $event
+     */
+    public function __construct(MailgunEvent $event)
+    {
+        $this->event = $event;
+    }
+}

--- a/src/Model/MailgunEvent.php
+++ b/src/Model/MailgunEvent.php
@@ -10,6 +10,11 @@ use Illuminate\Database\Eloquent\Model;
  */
 class MailgunEvent extends Model
 {
+
+    protected $dispatchesEvents = [
+        'saving' => Biegalski\LaravelMailgunWebhooks\Events\SaveEvent::class,
+    ];
+
     /**
      * The attributes that are mass assignable.
      *

--- a/src/Model/MailgunEvent.php
+++ b/src/Model/MailgunEvent.php
@@ -12,7 +12,7 @@ class MailgunEvent extends Model
 {
 
     protected $dispatchesEvents = [
-        'saving' => \Biegalski\LaravelMailgunWebhooks\Events\SaveEvent::class,
+        'created' => \Biegalski\LaravelMailgunWebhooks\Events\CreatedEvent::class,
     ];
 
     /**

--- a/src/Resources/lang/pl/email.php
+++ b/src/Resources/lang/pl/email.php
@@ -1,0 +1,43 @@
+<?php
+
+return [
+    'greeting' => 'Cześć,',
+    'clicks' => [
+        'subject' => 'Link kliknięty',
+        'desc' => 'Odbiorca kliknął na link w Twojej wiadomości, poniżej dane dotyczące tej wiadomości:'
+    ],
+    'delivered' => [
+        'subject' => 'Wiadomość dostarczona',
+        'desc' => 'Wiadomość została pomyślnie dostarczona do odbiorcy, poniżej dane dotyczące tej wiadomości:'
+    ],
+    'opened' => [
+        'subject' => 'Wiadomość otwarta',
+        'desc' => 'Wiadomość została otwarta przez odbiorcę, poniżej dane dotyczące tej wiadomości:'
+    ],
+    'perm_failure' => [
+        'subject' => 'Błąd dostarczania',
+        'desc' => 'Wiadomość napotkała błąd dostarczania (próby dostarczenia nie będą ponawiane), poniżej dane dotyczące tej wiadomości:'
+    ],
+    'spam' => [
+        'subject' => 'Zgłoszenie spamu',
+        'desc' => 'Niestety, ktoś zgłosił Twoją wiadomość jako spam, poniżej dane dotyczące tej wiadomości:'
+    ],
+    'temp_failure' => [
+        'subject' => 'Tymczasowy błąd dostarczania',
+        'desc' => 'Wiadomość napotkała tymczasowy błąd dostarczania (próby dostarczenia będą ponawiane), poniżej dane dotyczące tej wiadomości:'
+    ],
+    'unsubscribe' => [
+        'subject' => 'Wycofanie subskrypcji',
+        'desc' => 'Niestety, ktoś postanowił wycofać subskrypcję Twojej listy mailingowej, poniżej dane dotyczące tej wiadomości:'
+    ],
+    'fields' => [
+        'recipient' => 'Odbiorca',
+        'msg' => 'Dane wiadomości',
+        'msg_to' => 'Do',
+        'msg_id' => 'ID wiadomości',
+        'msg_from' => 'Od',
+        'msg_subject' => 'Temat',
+        'tags' => 'Etykiety',
+        'variables' => 'Zmienne'
+    ]
+];


### PR DESCRIPTION
With this small change you'll be able to hook your own listener to MailgunEvent model in order to react for changes in the model. I created it because I needed pusher notification updating my "sent emails" table in real time. I decided to use only "created" event since storing is as far as I know the only action that is executed on the model.

Example of implementation:

**app/Providers/EventServiceProvider.php**
`<?php
namespace App\Providers;

use Illuminate\Support\Facades\Event;
use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;

class EventServiceProvider extends ServiceProvider
{
    protected $listen = [       
        \Biegalski\LaravelMailgunWebhooks\Events\CreatedEvent::class => [
            \App\Listeners\MailgunEventListener::class, /* Your listener */
        ],
    ];

    public function boot()
    {
        parent::boot();
    }
}`