### PR TITLE
Add Mailgun HTTP webhook signing key configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ MAILGUN_WEBHOOKS_USER_TABLE_KEY=id
 MAILGUN_WEBHOOKS_USER_TABLE_FPQN=App\Users
 ```
 
+### Signing Key
+Mailgun allows you to set an HTTP webhook signing key, which can be different from the API key value set in the MAILGUN_SECRET environment variable used to connect to the Mailgun API for sending. This is especailly useful if you use Domain level sending API keys or have rotated the HTTP Webhook signing key. Defaults to the MAILGUN_SECRET value.
+```
+MAILGUN_WEBHOOKS_SIGNING_KEY=
+```
+
 After you've completed the configuration - lets re-cache it:
 
 `php artisan config:cache`

--- a/config/mailgun-webhooks.php
+++ b/config/mailgun-webhooks.php
@@ -42,5 +42,6 @@ return [
         'email_column' => env('MAILGUN_WEBHOOKS_USER_TABLE_EMAIL', 'email'),
         'identifier_key' => env('MAILGUN_WEBHOOKS_USER_TABLE_KEY', 'id'),
         'model_fpqn' => env('MAILGUN_WEBHOOKS_USER_TABLE_FPQN', 'App\User')
-    ]
+    ],
+    'signing_key' => env('MAILGUN_WEBHOOKS_SIGNING_KEY', null),
 ];

--- a/src/Middleware/ValidateMailgunWebhook.php
+++ b/src/Middleware/ValidateMailgunWebhook.php
@@ -44,7 +44,7 @@ class ValidateMailgunWebhook
         return hash_hmac(
             'sha256',
             sprintf('%s%s', $request->input('signature.timestamp'), $request->input('signature.token')),
-            config('services.mailgun.secret')
+            empty(config('mailgun-webhooks.signing_key')) ? config('services.mailgun.secret') : config('mailgun-webhooks.signing_key')
         );
     }
 


### PR DESCRIPTION
Fixes https://github.com/Biegalski-LLC/Laravel-Mailgun-Webhooks/issues/19

Adds a ENV variable for setting a HTTP webhook signing key, which could be different from the MAILGUN_SECRET, especially if you're using Domain level sending keys or have rotated the HTTP webhook signing key.