### PR TITLE
Allow publishing migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ Next, you will want to publish the configuration and view files.
 
 `php artisan vendor:publish --tag=mailgun_webhook_view`
 
+### Migrations
+
+Since the migrations for this package was made in 2019. They can cause problems with newer projects. \
+Using a user model for instance "App\Models\Customer" that was created after 2019. When running tests the migrations will be run on a mock database, which will cause the package migrations to be run before the customers table exist. The package migrations will try to create a relation to your user model. \
+
+To circumvent this, you can publish the migrations and manually change the timestamps in the file names.
+
+`php artisan vendor:publish --tag=mailgun_webhook_migrations`
+
 ## DotEnv Configuration Options
 
 Below you will find various options to configure this plugin to your needs.

--- a/src/LaravelMailgunWebhooksServiceProvider.php
+++ b/src/LaravelMailgunWebhooksServiceProvider.php
@@ -48,6 +48,13 @@ class LaravelMailgunWebhooksServiceProvider extends ServiceProvider
         ], 'mailgun_webhook_view');
 
         /**
+         * Publish migrations
+         */
+        $this->publishes([
+            __DIR__ . '/../database/migrations/' => database_path('migrations'),
+        ], 'mailgun_webhook_migrations');
+
+        /**
          * Load routes
          */
         $this->loadRoutesFrom(__DIR__ . '/routes.php');


### PR DESCRIPTION
I am not experienced enough to know if there is a better way.

Originally i faced a problem with the migrations when running tests. https://github.com/Biegalski-LLC/Laravel-Mailgun-Webhooks/issues/30

Dug a little deeper and found this solution.
Root cause:
Projects newer than the migrations in this package can have problems with the migration execution order when running all migrations from scratch.